### PR TITLE
Use conv=fdatasync instead of separate sync in disk check

### DIFF
--- a/lib/chirp/scripts/disk
+++ b/lib/chirp/scripts/disk
@@ -7,7 +7,7 @@ main() {
 
   : "${CHIRP_SCRATCH:=${TMPDIR:-/var/tmp}/chirp-disk}"
   : "${CHIRP_DISK_WRITES:=10000}"
-  : "${CHIRP_DISK_WRITE_SIZE_KB:=1024}"
+  : "${CHIRP_DISK_WRITE_SIZE_MB:=5}"
 
   mkdir -p "${CHIRP_SCRATCH}"
   pushd "${CHIRP_SCRATCH}"
@@ -16,12 +16,11 @@ main() {
   while [[ "${i}" -lt "${CHIRP_DISK_WRITES}" ]]; do
     dd if=/dev/zero \
       of="./.write-test-${i}" \
-      bs=1024 \
-      count="${CHIRP_DISK_WRITE_SIZE_KB}"
-    sync
+      conv=fdatasync \
+      bs=1M \
+      count="${CHIRP_DISK_WRITE_SIZE_MB}"
 
     rm -vf "./.write-test-${i}"
-    sync
 
     i=$((i + 1))
   done


### PR DESCRIPTION
and alter the block size and count to operate in MB.  When running this version of the script across infrastructures, I found the performance to be much more in line with what I've seen via other storage usage, e.g.:

### packet:
```
# bash -c 'time ./lib/chirp/scripts/disk &>/dev/null'                      

real    3m22.177s
user    0m3.964s
sys     0m40.092s
```

### ec2:
```
# bash -c 'time ./lib/chirp/scripts/disk &>/dev/null'                      

real    6m24.420s
user    0m16.631s
sys     1m20.132s
```